### PR TITLE
更新htmat crngen功能，修复共吸附bug

### DIFF
--- a/HTMACat/CRN.py
+++ b/HTMACat/CRN.py
@@ -1,4 +1,7 @@
 import requests
+import os
+import shutil
+from os.path import join
 
 def runCRN_net(configfname='ReactInfo'):
     with open(configfname) as f:
@@ -12,3 +15,245 @@ def runCRN_net(configfname='ReactInfo'):
     else:
         print('Success...')
         return r.text
+
+"""
+Created on July 26 20:37 2023.
+
+@author: RongxinChen
+"""
+
+def run_crnconfiggen(logname="CRNGenerator_log.txt"):
+    """
+        Generate the adsorption configurations for all intermediate species and 
+        polar subgraph elementary steps based on CRN log file. 
+    """
+    if os.path.exists(join(os.path.abspath('.'), 'stems')) or os.path.exists(join(os.path.abspath('.'), 'all_species')):
+        raise FileExistsError("The directories 'stems' and 'all_species' already exist in the current directory!\
+                              Please delete these directories and try again!")
+
+    smiles_list = crnlog_readspecies(logname)
+    create_input(smiles_list)
+    
+    stem_list = crnlog_getstems(logname)
+    stem_value = crnlog_readstems(stem_list)
+    create_stem_dir(stem_value)
+
+    if os.path.exists(join(join(join(os.path.abspath('.'), 'stems'), '0_stem'), '0_step')):
+        print('Success...')
+    else:
+        print('Generation failed, please recheck input information!')
+
+def crnlog_readspecies(inputfile):
+    '''
+    Return a str list for storing SMILES expressions for all reacting species.
+    '''
+    smiles_list = []
+    index_line = 0
+    index_smiles = 0
+    
+    with open(inputfile, 'r') as f:
+        f_lines = f.readlines()
+        start_line = 999
+        for line in f_lines:
+            if line[:26] == 'All possible species found':
+                # Cerify start_line
+                start_line = index_line+2
+            if index_line >= start_line:
+                if not line[0].isdigit():
+                    break
+                else:
+                    smiles_name = get_smilesname(line)
+                    smiles_list.append(smiles_name)
+            index_line += 1            
+    
+    return smiles_list
+    
+def get_smilesname(line):
+    '''
+    Return the SMILES expression from one line in log file
+    '''
+    judge_smlies = 0
+    init_index = 0
+    final_index = 0
+    strjudge_list = [' ', '(', ')']
+    
+    for i in range(len(line)):
+        if line[i] == ' ' and  (not (line[i+1] in strjudge_list)):
+            judge_smlies += 1
+            
+        if judge_smlies == 2 and init_index == 0:
+            init_index = i
+
+        final_index = i
+    return line[init_index+2:final_index]
+
+def create_input(smiles_list):
+    '''
+        Create a directory with the same name for each element in smiles_list and generate input files based on the template
+    '''
+    work_dir = os.path.abspath('.')
+    if not os.path.exists(join(work_dir,"config.yaml")):
+        raise ValueError("There is no template .yaml file!")
+        
+    illegal_list = ["\\", "/", "|"]
+    for i in range(len(smiles_list)):
+        new_dir = join(join(work_dir, 'all_species'),str(i)+'_'+smiles_list[i])        
+        for j in illegal_list:
+            if j in smiles_list[i] :
+                smiles_list[i].replace(j, '?')
+        os.makedirs(new_dir)
+        shutil.copy(join(work_dir,"config.yaml"), join(new_dir,"config.yaml"))    #Copy between dirs
+        change_config(join(new_dir,"config.yaml"), smiles_list[i])
+
+def change_config(filename, smiles_name):
+    '''
+        Generate config files based on species information
+    '''
+    with open(filename, 'r+') as f:
+        lines = f.readlines()
+        ads_line = 0
+        for i in range(len(lines)):
+            if 'ads' in lines[i][:10]:
+                ads_line = i
+        wds = lines[ads_line+1].split()
+        end_wds = wds[-1]
+        for wd in wds:
+            if wd[0] == '"' and wd[-2] == '"':
+                template_smiles = wd[1:-2]
+                
+    f1 = open(filename,"r")
+    content = f1.read()
+    f1.close()
+
+    t1 = content.replace(template_smiles, smiles_name)
+    f2 =  open(filename,"w") 
+    f2.write(t1)
+    f2.close
+
+class Stem:
+    '''
+    Attributes:
+        species: all species for subgraphs
+        steps: elementary steps for subgraphs
+    '''
+    def __init__(self, species, steps):
+        self.species = species
+        self.steps = steps
+    
+def crnlog_readstems(stem_list):
+    '''
+        Return: list
+            A list whose elements are Stem objects
+    '''
+    stem_value = []
+    for i in range(len(stem_list)):
+        _species, _steps = crnlog_analstem(stem_list[i])
+        stem_value.append(Stem(_species, _steps))
+    
+    return stem_value
+        
+                
+def crnlog_getstems(inputfile):
+    '''
+        Return: list
+            A list consisting of the row of each subgraph in CRNGenerator_log.txt
+    '''
+    with open(inputfile, 'r') as f:
+        f_lines = f.readlines()
+        stem_list = []
+        for i in range(len(f_lines)):
+            if f_lines[i][:3] == '***':
+                _startline = i
+                while (not not f_lines[i].strip()):
+                    i += 1
+                _finalline = i
+                stem_list.append(f_lines[_startline: _finalline])
+        return stem_list
+    
+def crnlog_analstem(stem):
+    '''
+        Return species and elementary steps information of a subgraph
+    '''
+    stem_species = []
+    for i in range(len(stem)):
+        if stem[i][:2]== '--' and i != 1:
+            _finalspeices = i
+            
+    for i in range(2, _finalspeices):
+        stem_species.append(stem[i].split()[-1])
+        
+    stem_step = []
+    for i in range(_finalspeices+1, len(stem)):
+        _step = stem[i].split()[-5:]
+        stem_step.append(_step)
+    return stem_species, stem_step
+
+def create_stem_dir(stem_value):
+    '''
+     Create directories for all subgraphs
+    '''
+    work_dir = os.path.abspath('.')
+    if not os.path.exists(join(work_dir,"config.yaml")):
+        raise ValueError("There is no template .yaml file!")
+        
+    for i in range(len(stem_value)):
+        for j in range(len(stem_value[i].steps)):
+            new_dir = join(join(join(work_dir, 'stems'), str(i)+'_stem'), str(j)+'_step')
+            os.makedirs(new_dir)
+            shutil.copy(join(work_dir, 'config.yaml'), join(new_dir, 'config_old.yaml'))    #用于目录之间的拷贝操作
+            change_stemconfig(join(new_dir,'config_old.yaml'), join(new_dir,'config.yaml'), stem_value[i].steps[j])
+            os.remove(join(new_dir, 'config_old.yaml'))
+    
+
+        
+def change_stemconfig(filename, newfilename, stem_step):
+    '''
+        modify config file based on the information of one of the elementay steps of a Stem.
+    '''
+    _idxarrow = -1
+    if '<-->' in stem_step:
+        _idxarrow = stem_step.index('<-->')
+
+    
+    coads_list = []
+    if _idxarrow == 1:
+        ads_name = stem_step[0]
+        coads_list.append(stem_step[2])
+        coads_list.append(stem_step[4])
+    elif _idxarrow == 3:
+        ads_name = stem_step[4]
+        coads_list.append(stem_step[0])
+        coads_list.append(stem_step[2])
+    else:
+        raise ValueError('Wrong stem format!')
+    
+    with open(filename, 'r') as f_old:
+        lines = f_old.readlines()
+        ads_line = 0
+        ads_wdgap = 0
+        for i in range(len(lines)):
+            if 'ads' in lines[i][:10]:
+                ads_line = i
+                
+        for i in range(len(lines[ads_line+1])):
+            if lines[ads_line+1][i] != ' ':
+                ads_wdgap = i
+                break
+        wds = lines[ads_line+1].split()
+        end_wds = wds[-1]
+        for wd in wds:
+            if wd[0] == '"' and wd[-2] == '"':
+                template_smiles = wd[1:-2]
+    
+    with open(newfilename, 'w') as f_new:
+        idx_line = -1
+        for line in lines:
+            idx_line += 1
+            if idx_line == ads_line+1:
+                modified_line = lines[ads_line+1].replace(template_smiles, ads_name)
+                f_new.write(modified_line)
+                f_new.write(lines[ads_line].replace('ads', 'coads'))
+                f_new.write(' '*ads_wdgap+'- [s: "'+coads_list[0]+'", s: "'+coads_list[1]+'", 1, 1]')
+                break
+            else:
+                f_new.write(line)

--- a/HTMACat/command.py
+++ b/HTMACat/command.py
@@ -2,6 +2,7 @@ import os
 from HTMACat.model.Construct_adsorption_yaml import *
 from HTMACat.IO import print_templator, out_templator_file, yaml2dict
 from HTMACat.CRN import runCRN_net
+from HTMACat.CRN import run_crnconfiggen
 from HTMACat.__version__ import __title__, __version__
 from pathlib import *
 import shutil
@@ -73,3 +74,8 @@ def crn():
     """Generate the Chemical Reaction Network."""
     with open('CRNGenerator_log.txt', 'w') as f:
         f.write(runCRN_net())
+
+@htmat.command(context_settings=CONTEXT_SETTINGS)
+def crngen():
+    """Generate structured directories and input files based on CRNGenerator_log.txt"""
+    run_crnconfiggen()

--- a/HTMACat/model/Ads.py
+++ b/HTMACat/model/Ads.py
@@ -165,14 +165,15 @@ class Coadsorption(Adsorption):
         )
 
     def construct(self):
-        if self.get_sites() == "1 1":
+        ### Change by RxChen, 2023 7 26:
+        if self.get_sites() == ['1','1']:
             slabs_ads = self.Construct_coadsorption_11()
-        elif self.get_sites() == "1 2":
+        elif self.get_sites() == ['1','2']:
             slabs_ads = self.Construct_coadsorption_12()
-        elif self.get_sites() == "2 2":
+        elif self.get_sites() == ['2','2']:
             slabs_ads = self.Construct_coadsorption_22()
         else:
-            raise ValueError('Supports only "1 1" "1 2" "2 2" adsorption sites for coads!')
+            raise ValueError("Supports only ['1','1'] ['1','2'] ['2','2'] adsorption sites for coads!")### end
         if self.substrate.is_dope():
             slabs_ads = self.remove_same(slabs_ads)
         return slabs_ads

--- a/HTMACat/model/Species.py
+++ b/HTMACat/model/Species.py
@@ -137,9 +137,9 @@ class Sml_Species(ABS_Species):
         _idxtmp1 = rdMolDescriptors.CalcMolFormula(mole).find('+')
         if -1 == _idxtmp and -1 == _idxtmp1:
             form_str = rdMolDescriptors.CalcMolFormula(mole)
-        elif _idxtmp != 1 and _idxtmp1 == -1:
+        elif _idxtmp != -1 and _idxtmp1 == -1:
             form_str = rdMolDescriptors.CalcMolFormula(mole)[:_idxtmp]
-        elif _idxtmp == -1 and _idxtmp1 != 1:
+        elif _idxtmp == -1 and _idxtmp1 != -1:
             form_str = rdMolDescriptors.CalcMolFormula(mole)[:_idxtmp1]
         else:
             raise ValueError('Invalid SMILES')

--- a/example/CRN_2_htma_demo/CRNGenerator_log.txt
+++ b/example/CRN_2_htma_demo/CRNGenerator_log.txt
@@ -1,0 +1,332 @@
+['C2H6 -> C2H4 + C2H2 + H2', '8', 'Reactants', 'CC', 'Products', 'C=C', 'C#C', '[H][H]']
+
+All possible species found (17 in total):
+No.                     Chemical_form       	SMILES
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+4                       C                   	[C-4]
+5                       C2                  	[C-]#[C-]
+6                       H                   	[H+]
+7                       CH                  	[CH-3]
+8                       C2H                 	[C-]#C
+9                       CH2                 	[CH2-2]
+10                      C2H2                	[C-2]=C
+11                      CH3                 	[CH3-]
+12                      C2H3                	[C-3]C
+13                      C2H3                	[CH-]=C
+14                      C2H4                	[CH-2]C
+15                      C2H5                	[CH2-]C
+16                      CH4                 	C
+
+所有可能的基元反应 All possible reactions
+ 27 reactions in total:
+0)    1  +  6  <->  15        C2H4  +  H  <->  C2H5         	C=C  +  [H+]  <->  [CH2-]C
+1)    2  +  6  <->  13        C2H2  +  H  <->  C2H3         	C#C  +  [H+]  <->  [CH-]=C
+2)    4  +  4  <->  5         C  +  C  <->  C2              	[C-4]  +  [C-4]  <->  [C-]#[C-]
+3)    4  +  6  <->  7         C  +  H  <->  CH              	[C-4]  +  [H+]  <->  [CH-3]
+4)    4  +  7  <->  8         C  +  CH  <->  C2H            	[C-4]  +  [CH-3]  <->  [C-]#C
+5)    4  +  9  <->  10        C  +  CH2  <->  C2H2          	[C-4]  +  [CH2-2]  <->  [C-2]=C
+6)    4  +  11  <->  12       C  +  CH3  <->  C2H3          	[C-4]  +  [CH3-]  <->  [C-3]C
+7)    5  +  6  <->  8         C2  +  H  <->  C2H            	[C-]#[C-]  +  [H+]  <->  [C-]#C
+8)    6  +  6  <->  3         H  +  H  <->  H2              	[H+]  +  [H+]  <->  [H][H]
+9)    6  +  7  <->  9         H  +  CH  <->  CH2            	[H+]  +  [CH-3]  <->  [CH2-2]
+10)   6  +  8  <->  10        H  +  C2H  <->  C2H2          	[H+]  +  [C-]#C  <->  [C-2]=C
+11)   6  +  8  <->  2         H  +  C2H  <->  C2H2          	[H+]  +  [C-]#C  <->  C#C
+12)   6  +  9  <->  11        H  +  CH2  <->  CH3           	[H+]  +  [CH2-2]  <->  [CH3-]
+13)   6  +  10  <->  12       H  +  C2H2  <->  C2H3         	[H+]  +  [C-2]=C  <->  [C-3]C
+14)   6  +  10  <->  13       H  +  C2H2  <->  C2H3         	[H+]  +  [C-2]=C  <->  [CH-]=C
+15)   6  +  11  <->  16       H  +  CH3  <->  CH4           	[H+]  +  [CH3-]  <->  C
+16)   6  +  12  <->  14       H  +  C2H3  <->  C2H4         	[H+]  +  [C-3]C  <->  [CH-2]C
+17)   6  +  13  <->  14       H  +  C2H3  <->  C2H4         	[H+]  +  [CH-]=C  <->  [CH-2]C
+18)   6  +  13  <->  1        H  +  C2H3  <->  C2H4         	[H+]  +  [CH-]=C  <->  C=C
+19)   6  +  14  <->  15       H  +  C2H4  <->  C2H5         	[H+]  +  [CH-2]C  <->  [CH2-]C
+20)   0  <->  6  +  15        C2H6  <->  H  +  C2H5         	CC  <->  [H+]  +  [CH2-]C
+21)   7  +  7  <->  2         CH  +  CH  <->  C2H2          	[CH-3]  +  [CH-3]  <->  C#C
+22)   7  +  9  <->  13        CH  +  CH2  <->  C2H3         	[CH-3]  +  [CH2-2]  <->  [CH-]=C
+23)   7  +  11  <->  14       CH  +  CH3  <->  C2H4         	[CH-3]  +  [CH3-]  <->  [CH-2]C
+24)   9  +  9  <->  1         CH2  +  CH2  <->  C2H4        	[CH2-2]  +  [CH2-2]  <->  C=C
+25)   9  +  11  <->  15       CH2  +  CH3  <->  C2H5        	[CH2-2]  +  [CH3-]  <->  [CH2-]C
+26)   0  <->  11  +  11       C2H6  <->  CH3  +  CH3        	CC  <->  [CH3-]  +  [CH3-]
+
+
+
+================ The Complete CRN ================
+总反应网络
+
+
+Species (16 in total):
+No.                     Chemical_form       	SMILES
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+4                       C                   	[C-4]
+5                       C2                  	[C-]#[C-]
+6                       H                   	[H+]
+7                       CH                  	[CH-3]
+8                       C2H                 	[C-]#C
+9                       CH2                 	[CH2-2]
+10                      C2H2                	[C-2]=C
+11                      CH3                 	[CH3-]
+12                      C2H3                	[C-3]C
+13                      C2H3                	[CH-]=C
+14                      C2H4                	[CH-2]C
+15                      C2H5                	[CH2-]C
+
+26 reactions in total:
+0)    1  +  6  <->  15        C2H4  +  H  <->  C2H5         	C=C  +  [H+]  <->  [CH2-]C
+1)    2  +  6  <->  13        C2H2  +  H  <->  C2H3         	C#C  +  [H+]  <->  [CH-]=C
+2)    4  +  4  <->  5         C  +  C  <->  C2              	[C-4]  +  [C-4]  <->  [C-]#[C-]
+3)    4  +  6  <->  7         C  +  H  <->  CH              	[C-4]  +  [H+]  <->  [CH-3]
+4)    4  +  7  <->  8         C  +  CH  <->  C2H            	[C-4]  +  [CH-3]  <->  [C-]#C
+5)    4  +  9  <->  10        C  +  CH2  <->  C2H2          	[C-4]  +  [CH2-2]  <->  [C-2]=C
+6)    4  +  11  <->  12       C  +  CH3  <->  C2H3          	[C-4]  +  [CH3-]  <->  [C-3]C
+7)    5  +  6  <->  8         C2  +  H  <->  C2H            	[C-]#[C-]  +  [H+]  <->  [C-]#C
+8)    6  +  6  <->  3         H  +  H  <->  H2              	[H+]  +  [H+]  <->  [H][H]
+9)    6  +  7  <->  9         H  +  CH  <->  CH2            	[H+]  +  [CH-3]  <->  [CH2-2]
+10)   6  +  8  <->  10        H  +  C2H  <->  C2H2          	[H+]  +  [C-]#C  <->  [C-2]=C
+11)   6  +  8  <->  2         H  +  C2H  <->  C2H2          	[H+]  +  [C-]#C  <->  C#C
+12)   6  +  9  <->  11        H  +  CH2  <->  CH3           	[H+]  +  [CH2-2]  <->  [CH3-]
+13)   6  +  10  <->  12       H  +  C2H2  <->  C2H3         	[H+]  +  [C-2]=C  <->  [C-3]C
+14)   6  +  10  <->  13       H  +  C2H2  <->  C2H3         	[H+]  +  [C-2]=C  <->  [CH-]=C
+16)   6  +  12  <->  14       H  +  C2H3  <->  C2H4         	[H+]  +  [C-3]C  <->  [CH-2]C
+17)   6  +  13  <->  14       H  +  C2H3  <->  C2H4         	[H+]  +  [CH-]=C  <->  [CH-2]C
+18)   6  +  13  <->  1        H  +  C2H3  <->  C2H4         	[H+]  +  [CH-]=C  <->  C=C
+19)   6  +  14  <->  15       H  +  C2H4  <->  C2H5         	[H+]  +  [CH-2]C  <->  [CH2-]C
+20)   0  <->  6  +  15        C2H6  <->  H  +  C2H5         	CC  <->  [H+]  +  [CH2-]C
+21)   7  +  7  <->  2         CH  +  CH  <->  C2H2          	[CH-3]  +  [CH-3]  <->  C#C
+22)   7  +  9  <->  13        CH  +  CH2  <->  C2H3         	[CH-3]  +  [CH2-2]  <->  [CH-]=C
+23)   7  +  11  <->  14       CH  +  CH3  <->  C2H4         	[CH-3]  +  [CH3-]  <->  [CH-2]C
+24)   9  +  9  <->  1         CH2  +  CH2  <->  C2H4        	[CH2-2]  +  [CH2-2]  <->  C=C
+25)   9  +  11  <->  15       CH2  +  CH3  <->  C2H5        	[CH2-2]  +  [CH3-]  <->  [CH2-]C
+26)   0  <->  11  +  11       C2H6  <->  CH3  +  CH3        	CC  <->  [CH3-]  +  [CH3-]
+
+
+
+
+=================== Stem CRNs ===================
+以下是搜寻到的极小主干网络，共 7 个：
+
+
+*** Stem CRN 0:
+-- 7 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+13                      C2H3                	[CH-]=C
+15                      C2H5                	[CH2-]C
+-- 5 reactions involved:
+0)    1  +  6  <-->  15       C2H4  +  H  <-->  C2H5        	C=C  +  [H+]  <-->  [CH2-]C
+1)    2  +  6  <-->  13       C2H2  +  H  <-->  C2H3        	C#C  +  [H+]  <-->  [CH-]=C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+18)   6  +  13  <-->  1       H  +  C2H3  <-->  C2H4        	[H+]  +  [CH-]=C  <-->  C=C
+20)   0  <-->  6  +  15       C2H6  <-->  H  +  C2H5        	CC  <-->  [H+]  +  [CH2-]C
+
+
+*** Stem CRN 1:
+-- 8 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+9                       CH2                 	[CH2-2]
+11                      CH3                 	[CH3-]
+13                      C2H3                	[CH-]=C
+-- 6 reactions involved:
+1)    2  +  6  <-->  13       C2H2  +  H  <-->  C2H3        	C#C  +  [H+]  <-->  [CH-]=C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+12)   6  +  9  <-->  11       H  +  CH2  <-->  CH3          	[H+]  +  [CH2-2]  <-->  [CH3-]
+18)   6  +  13  <-->  1       H  +  C2H3  <-->  C2H4        	[H+]  +  [CH-]=C  <-->  C=C
+24)   9  +  9  <-->  1        CH2  +  CH2  <-->  C2H4       	[CH2-2]  +  [CH2-2]  <-->  C=C
+26)   0  <-->  11  +  11      C2H6  <-->  CH3  +  CH3       	CC  <-->  [CH3-]  +  [CH3-]
+
+
+*** Stem CRN 2:
+-- 10 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+8                       C2H                 	[C-]#C
+10                      C2H2                	[C-2]=C
+12                      C2H3                	[C-3]C
+14                      C2H4                	[CH-2]C
+15                      C2H5                	[CH2-]C
+-- 8 reactions involved:
+0)    1  +  6  <-->  15       C2H4  +  H  <-->  C2H5        	C=C  +  [H+]  <-->  [CH2-]C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+10)   6  +  8  <-->  10       H  +  C2H  <-->  C2H2         	[H+]  +  [C-]#C  <-->  [C-2]=C
+11)   6  +  8  <-->  2        H  +  C2H  <-->  C2H2         	[H+]  +  [C-]#C  <-->  C#C
+13)   6  +  10  <-->  12      H  +  C2H2  <-->  C2H3        	[H+]  +  [C-2]=C  <-->  [C-3]C
+16)   6  +  12  <-->  14      H  +  C2H3  <-->  C2H4        	[H+]  +  [C-3]C  <-->  [CH-2]C
+19)   6  +  14  <-->  15      H  +  C2H4  <-->  C2H5        	[H+]  +  [CH-2]C  <-->  [CH2-]C
+20)   0  <-->  6  +  15       C2H6  <-->  H  +  C2H5        	CC  <-->  [H+]  +  [CH2-]C
+
+
+*** Stem CRN 3:
+-- 9 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+7                       CH                  	[CH-3]
+11                      CH3                 	[CH3-]
+14                      C2H4                	[CH-2]C
+15                      C2H5                	[CH2-]C
+-- 7 reactions involved:
+0)    1  +  6  <-->  15       C2H4  +  H  <-->  C2H5        	C=C  +  [H+]  <-->  [CH2-]C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+19)   6  +  14  <-->  15      H  +  C2H4  <-->  C2H5        	[H+]  +  [CH-2]C  <-->  [CH2-]C
+20)   0  <-->  6  +  15       C2H6  <-->  H  +  C2H5        	CC  <-->  [H+]  +  [CH2-]C
+21)   7  +  7  <-->  2        CH  +  CH  <-->  C2H2         	[CH-3]  +  [CH-3]  <-->  C#C
+23)   7  +  11  <-->  14      CH  +  CH3  <-->  C2H4        	[CH-3]  +  [CH3-]  <-->  [CH-2]C
+26)   0  <-->  11  +  11      C2H6  <-->  CH3  +  CH3       	CC  <-->  [CH3-]  +  [CH3-]
+
+
+*** Stem CRN 4:
+-- 8 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+7                       CH                  	[CH-3]
+9                       CH2                 	[CH2-2]
+15                      C2H5                	[CH2-]C
+-- 6 reactions involved:
+0)    1  +  6  <-->  15       C2H4  +  H  <-->  C2H5        	C=C  +  [H+]  <-->  [CH2-]C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+9)    6  +  7  <-->  9        H  +  CH  <-->  CH2           	[H+]  +  [CH-3]  <-->  [CH2-2]
+20)   0  <-->  6  +  15       C2H6  <-->  H  +  C2H5        	CC  <-->  [H+]  +  [CH2-]C
+21)   7  +  7  <-->  2        CH  +  CH  <-->  C2H2         	[CH-3]  +  [CH-3]  <-->  C#C
+24)   9  +  9  <-->  1        CH2  +  CH2  <-->  C2H4       	[CH2-2]  +  [CH2-2]  <-->  C=C
+
+
+*** Stem CRN 5:
+-- 8 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+6                       H                   	[H+]
+7                       CH                  	[CH-3]
+9                       CH2                 	[CH2-2]
+11                      CH3                 	[CH3-]
+-- 6 reactions involved:
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+9)    6  +  7  <-->  9        H  +  CH  <-->  CH2           	[H+]  +  [CH-3]  <-->  [CH2-2]
+12)   6  +  9  <-->  11       H  +  CH2  <-->  CH3          	[H+]  +  [CH2-2]  <-->  [CH3-]
+21)   7  +  7  <-->  2        CH  +  CH  <-->  C2H2         	[CH-3]  +  [CH-3]  <-->  C#C
+24)   9  +  9  <-->  1        CH2  +  CH2  <-->  C2H4       	[CH2-2]  +  [CH2-2]  <-->  C=C
+26)   0  <-->  11  +  11      C2H6  <-->  CH3  +  CH3       	CC  <-->  [CH3-]  +  [CH3-]
+
+
+*** Stem CRN 6:
+-- 12 involved species:
+0 (Reactant)            C2H6                	CC
+1 (Product)             C2H4                	C=C
+2 (Product)             C2H2                	C#C
+3 (Product)             H2                  	[H][H]
+4                       C                   	[C-4]
+5                       C2                  	[C-]#[C-]
+6                       H                   	[H+]
+8                       C2H                 	[C-]#C
+11                      CH3                 	[CH3-]
+12                      C2H3                	[C-3]C
+14                      C2H4                	[CH-2]C
+15                      C2H5                	[CH2-]C
+-- 10 reactions involved:
+0)    1  +  6  <-->  15       C2H4  +  H  <-->  C2H5        	C=C  +  [H+]  <-->  [CH2-]C
+2)    4  +  4  <-->  5        C  +  C  <-->  C2             	[C-4]  +  [C-4]  <-->  [C-]#[C-]
+6)    4  +  11  <-->  12      C  +  CH3  <-->  C2H3         	[C-4]  +  [CH3-]  <-->  [C-3]C
+7)    5  +  6  <-->  8        C2  +  H  <-->  C2H           	[C-]#[C-]  +  [H+]  <-->  [C-]#C
+8)    6  +  6  <-->  3        H  +  H  <-->  H2             	[H+]  +  [H+]  <-->  [H][H]
+11)   6  +  8  <-->  2        H  +  C2H  <-->  C2H2         	[H+]  +  [C-]#C  <-->  C#C
+16)   6  +  12  <-->  14      H  +  C2H3  <-->  C2H4        	[H+]  +  [C-3]C  <-->  [CH-2]C
+19)   6  +  14  <-->  15      H  +  C2H4  <-->  C2H5        	[H+]  +  [CH-2]C  <-->  [CH2-]C
+20)   0  <-->  6  +  15       C2H6  <-->  H  +  C2H5        	CC  <-->  [H+]  +  [CH2-]C
+26)   0  <-->  11  +  11      C2H6  <-->  CH3  +  CH3       	CC  <-->  [CH3-]  +  [CH3-]
+
+
+
+
+
+
+Species_topological (17 in total):
+
+0 (Reactant)    C2H6		CC
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H'), (5, 'H'), (6, 'H'), (7, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5), (1, 6), (1, 7)]
+
+1 (Product)     C2H4		C=C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H'), (5, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (1, 4), (1, 5)]
+
+2 (Product)     C2H2		C#C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H')]
+edges: [(0, 1), (0, 2), (1, 3)]
+
+3 (Product)     H2		[H][H]
+nodes: [(0, 'H'), (1, 'H')]
+edges: [(0, 1)]
+
+4               C		[C-4]
+nodes: [(0, 'C')]
+edges: []
+
+5               C2		[C-]#[C-]
+nodes: [(0, 'C'), (1, 'C')]
+edges: [(0, 1)]
+
+6               H		[H+]
+nodes: [(0, 'H')]
+edges: []
+
+7               CH		[CH-3]
+nodes: [(0, 'C'), (1, 'H')]
+edges: [(0, 1)]
+
+8               C2H		[C-]#C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H')]
+edges: [(0, 1), (0, 2)]
+
+9               CH2		[CH2-2]
+nodes: [(0, 'C'), (1, 'H'), (2, 'H')]
+edges: [(0, 1), (0, 2)]
+
+10              C2H2		[C-2]=C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H')]
+edges: [(0, 1), (0, 2), (0, 3)]
+
+11              CH3		[CH3-]
+nodes: [(0, 'C'), (1, 'H'), (2, 'H'), (3, 'H')]
+edges: [(0, 1), (0, 2), (0, 3)]
+
+12              C2H3		[C-3]C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (0, 4)]
+
+13              C2H3		[CH-]=C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (1, 4)]
+
+14              C2H4		[CH-2]C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H'), (5, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5)]
+
+15              C2H5		[CH2-]C
+nodes: [(0, 'C'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H'), (5, 'H'), (6, 'H')]
+edges: [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5), (1, 6)]
+
+16              CH4		C
+nodes: [(0, 'H'), (1, 'C'), (2, 'H'), (3, 'H'), (4, 'H')]
+edges: [(0, 1), (1, 2), (1, 3), (1, 4)]
+
+

--- a/example/CRN_2_htma_demo/all_species/0_CC/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/0_CC/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/10_[C-2]=C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/10_[C-2]=C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-2]=C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/11_[CH3-]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/11_[CH3-]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH3-]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/12_[C-3]C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/12_[C-3]C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-3]C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/13_[CH-]=C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/13_[CH-]=C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-]=C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/14_[CH-2]C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/14_[CH-2]C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-2]C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/15_[CH2-]C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/15_[CH2-]C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/16_C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/16_C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/1_C=C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/1_C=C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/2_C#C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/2_C#C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/3_[H][H]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/3_[H][H]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/4_[C-4]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/4_[C-4]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-4]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/5_[C-]#[C-]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/5_[C-]#[C-]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-]#[C-]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/6_[H+]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/6_[H+]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H+]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/7_[CH-3]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/7_[CH-3]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-3]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/8_[C-]#C/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/8_[C-]#C/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-]#C", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/all_species/9_[CH2-2]/config.yaml
+++ b/example/CRN_2_htma_demo/all_species/9_[CH2-2]/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-2]", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/config.yaml
+++ b/example/CRN_2_htma_demo/config.yaml
@@ -1,0 +1,13 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CCC", 1] # The SMILES form is required here, and the adsorption method can be customized.

--- a/example/CRN_2_htma_demo/stems/0_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/0_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C=C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/0_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/0_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-]=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C#C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/0_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/0_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/0_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/0_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-]=C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/0_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/0_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-]=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C#C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH3-]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-2]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-]=C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH2-2]", s: "[CH2-2]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/1_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/1_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH3-]", s: "[CH3-]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C=C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-2]=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-]#C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-]#C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-3]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-2]=C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-2]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-3]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/6_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/6_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-2]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/2_stem/7_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/2_stem/7_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C=C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-2]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH-3]", s: "[CH-3]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-2]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH-3]", s: "[CH3-]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/3_stem/6_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/3_stem/6_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH3-]", s: "[CH3-]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C=C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-2]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-3]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH-3]", s: "[CH-3]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/4_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/4_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH2-2]", s: "[CH2-2]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-2]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-3]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH3-]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-2]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH-3]", s: "[CH-3]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C=C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH2-2]", s: "[CH2-2]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/5_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/5_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH3-]", s: "[CH3-]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/0_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/0_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "C=C", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/1_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/1_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-]#[C-]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[C-4]", s: "[C-4]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/2_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/2_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-3]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[C-4]", s: "[CH3-]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/3_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/3_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[C-]#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[C-]#[C-]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/4_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/4_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[H][H]", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[H+]", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/5_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/5_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "C#C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-]#C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/6_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/6_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH-2]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[C-3]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/7_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/7_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "[CH2-]C", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH-2]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/8_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/8_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[H+]", s: "[CH2-]C", 1, 1]

--- a/example/CRN_2_htma_demo/stems/6_stem/9_step/config.yaml
+++ b/example/CRN_2_htma_demo/stems/6_stem/9_step/config.yaml
@@ -1,0 +1,15 @@
+# This is a template file where you need to define the structure you want to build (in addition to the adsorbate).
+StrucInfo:
+  struct:
+    element: Pt
+    lattice_type: fcc
+    lattice_constant: 4.16
+    facet: ["100"]
+    dope:
+      Cu: ["0"]
+
+Model:
+  ads:
+    - [s: "CC", 1] # The SMILES form is required here, and the adsorption method can be customized.
+  coads:
+    - [s: "[CH3-]", s: "[CH3-]", 1, 1]


### PR DESCRIPTION
更新htmat crngen功能，可以基于CRNGeneratoe_log.txt文件，生成反应网络中包含的所有物种以及全部极简子图的基元步中初态和末态对应构型的yaml文件，并生成对应的树状目录。
修复更新调整吸附物位相功能后，共吸附功能无法正常使用的bug。