### PR TITLE
功能扩展：吸附构型“打分”，可挑选优秀构型，在新的吸附物位向确定模式（direction='hetero'）中生效

### DIFF
--- a/HTMACat/catkit/gen/utils/__init__.py
+++ b/HTMACat/catkit/gen/utils/__init__.py
@@ -10,11 +10,13 @@ from .utilities import (running_mean, to_gratoms, get_atomic_numbers,
 from .utils_mdnm import (mol_to_graph,
                          solve_normal_vector_linearsvc,
                          solve_normal_vector_pca,
+                         solve_normal_vector_hetero,
                          solve_principle_axe_pca,
                          Check_treatable__HTMATver,
                          Gen_conn_mole,
                          center_molecule,
-                         center_slab,)
+                         center_slab,
+                         score_configuration_hetero,)
 
 __all__ = ['get_voronoi_neighbors',
            'get_cutoff_neighbors',
@@ -40,8 +42,10 @@ __all__ = ['get_voronoi_neighbors',
            'mol_to_graph',
            'solve_normal_vector_linearsvc',
            'solve_normal_vector_pca',
+           'solve_normal_vector_hetero',
            'solve_principle_axe_pca',
            'Check_treatable__HTMATver',
            'Gen_conn_mole',
            'center_molecule',
-           'center_slab']
+           'center_slab',
+           'score_configuration_hetero']

--- a/HTMACat/catkit/gen/utils/utils_mdnm.py
+++ b/HTMACat/catkit/gen/utils/utils_mdnm.py
@@ -4,6 +4,7 @@ import numpy as np
 from sklearn.svm import SVC
 from sklearn.decomposition import PCA
 from rdkit import Chem
+from ase.data import atomic_numbers, covalent_radii
 
 def mol_to_graph(self, m):
     """Convert a molecule object to a graph.
@@ -108,6 +109,16 @@ def solve_normal_vector_pca(coords, bond_idx):
     if np.dot(vec,(Center_coord-coords[bond_idx])) < 0:
         vec = -vec
     return vec # return M3
+
+def solve_normal_vector_hetero(coords, symbols):
+    centroid = np.mean(coords, axis=0)
+    coords_hetero = []
+    for i,coord in enumerate(coords):
+        if not symbols[i] in ['C', 'H']:
+            coords_hetero.append(coord)
+    centroid_hetero = np.mean(coords_hetero, axis=0)
+    vec = centroid - centroid_hetero
+    return vec, centroid, centroid_hetero
 
 def solve_principle_axe_pca(coords):
     """PCA: 2D to 1D, using x & y coords of atoms in an adsorbate
@@ -245,4 +256,160 @@ def center_slab(final_positions):
 
     return center_x, center_y
 
+# 吸附构型评价相关
 
+# Pauling 电负性数据
+pauling_en = {
+    'H': 2.20, #
+    'Li': 0.98,
+    'Be': 1.57,
+    'B': 2.04,
+    'C': 2.55,
+    'N': 3.04,
+    'O': 3.44,
+    'F': 3.98, #
+    'Na': 0.93,
+    'Mg': 1.31,
+    'Al': 1.61,
+    'Si': 1.90,
+    'P': 2.19,
+    'S': 2.58,
+    'Cl': 3.16, #
+    'K': 0.82,
+    'Ca': 1.00,
+    'Sc': 1.36,
+    'Ti': 1.54,
+    'V': 1.63,
+    'Cr': 1.66,
+    'Mn': 1.55,
+    'Fe': 1.83,
+    'Co': 1.88,
+    'Ni': 1.91,
+    'Cu': 1.90,
+    'Zn': 1.65,
+    'Ga': 1.81,
+    'Ge': 2.01,
+    'As': 2.18,
+    'Se': 2.55,
+    'Br': 2.96,
+    'Kr': 3.00,
+    'Rb': 0.82, #
+    'Sr': 0.95,
+    'Y': 1.22,
+    'Zr': 1.33,
+    'Nb': 1.60,
+    'Mo': 2.16,
+    'Tc': 2.10,
+    'Ru': 2.20,
+    'Rh': 2.28,
+    'Pd': 2.20,
+    'Ag': 1.93,
+    'Cd': 1.69,
+    'In': 1.78,
+    'Sn': 1.96,
+    'Sb': 2.05,
+    'Te': 2.10,
+    'I': 2.66,
+    'Xe': 2.60,
+    'Cs': 0.79,
+    'Ba': 0.89,
+    'La': 1.10,
+    'Ce': 1.12,
+    'Pr': 1.13,
+    'Nd': 1.14,
+    'Pm': 1.13,
+    'Sm': 1.17,
+    'Eu': 1.20,
+    'Gd': 1.20,
+    'Tb': 1.20,
+    'Dy': 1.22,
+    'Ho': 1.23,
+    'Er': 1.24,
+    'Tm': 1.25,
+    'Yb': 1.10,
+    'Lu': 1.27,
+    'Hf': 1.30,
+    'Ta': 1.50,
+    'W': 2.36,
+    'Re': 2.20,
+    'Os': 2.20,
+    'Ir': 2.20,
+    'Pt': 2.28,
+    'Au': 2.54,
+    'Hg': 2.00,
+    'Tl': 1.82,
+    'Pb': 2.33,
+    'Bi': 2.02,
+    'Po': 2.00,
+    'At': 2.20,
+    'Rn': 2.20,
+    'Fr': 0.70,
+    'Ra': 0.90,
+    'Ac': 1.10,
+    'Th': 1.30,
+    'Pa': 1.50,
+    'U': 1.38,
+    'Np': 1.36,
+    'Pu': 1.28,
+    'Am': 1.30,
+    'Cm': 1.30,
+    'Bk': 1.30,
+    'Cf': 1.30,
+    'Es': 1.30,
+    'Fm': 1.30,
+    'Md': 1.30,
+    'No': 1.30,
+    'Lr': 1.30,
+    'Rf': 1.50,
+    'Db': 1.50,
+    'Sg': 1.50,
+    'Bh': 1.50,
+    'Hs': 1.50,
+    'Mt': 1.50,
+    'Ds': 1.50,
+    'Rg': 1.50,
+    'Cn': 1.50,
+    'Nh': 1.50,
+    'Fl': 1.50,
+    'Mc': 1.50,
+    'Lv': 1.50,
+    'Ts': 1.50,
+    'Og': 1.50,
+}
+
+def fitness_01(distance, rsum, EN): # hetero <-> metallic_site
+    return EN * ( (2*distance/rsum)**(-1) - (2*distance/rsum)**-2 ) * 4
+
+def score_configuration_hetero(coords, symbols, z_surf):
+    # print('*** test', fitness_01(1.8, 1.8, 3.0)) # = 3
+    # print('*** test', fitness_01(0.9, 1.8, 3.0)) # = 0
+    # print('*** test', fitness_01(1.8*1.5, 1.8, 3.0)) # = 2.667
+    idx_hetero = [] # 记录各个杂原子在coords中的index
+    neigh_of_hetero = [] # 记录idx_hetero中对应的各个杂原子的‘邻近表面原子’在coords中的index列表
+    neigh_dist_of_hetero = [] # 与neigh_of_hetero同形，记录对应的距离
+    neigh_rsum_of_hetero = [] # 与neigh_of_hetero同形，记录对应的共价半径之和rsum
+    for idx,coord in enumerate(coords):
+        if (coord[2] > z_surf) and (not symbols[idx] in ['C', 'H']):
+            idx_hetero.append(idx)
+            tmp_neighl = []
+            tmp_distl = []
+            tmp_rsuml = []
+            for idxn,coordn in enumerate(coords):
+                if abs(coordn[2] - z_surf) < 0.1:
+                    d = np.sqrt( np.sum( np.dot(coord-coordn,coord-coordn) ) )
+                    rsum = covalent_radii[atomic_numbers[symbols[idx]]] + covalent_radii[atomic_numbers[symbols[idxn]]]
+                    if d < 1.5*rsum:
+                        tmp_neighl.append(idxn)
+                        tmp_distl.append(d)
+                        tmp_rsuml.append(rsum)
+            neigh_of_hetero.append(tmp_neighl)
+            neigh_dist_of_hetero.append(tmp_distl)
+            neigh_rsum_of_hetero.append(tmp_rsuml)
+    # calc score
+    score = 0
+    for idx_a,atom_i in enumerate(idx_hetero):
+        for idx_n,atom_j in enumerate(neigh_of_hetero[idx_a]):
+            score = score + fitness_01(distance=neigh_dist_of_hetero[idx_a][idx_n],
+                                       rsum=neigh_rsum_of_hetero[idx_a][idx_n],
+                                       EN=pauling_en[symbols[atom_i]])
+    return score

--- a/HTMACat/model/Ads.py
+++ b/HTMACat/model/Ads.py
@@ -181,12 +181,18 @@ class Adsorption(Structure):
                         coord_ = coord
                     # confirm z coord (height of the adsorbate)
                     for bond_id in bond_atom_ids:
-                        slab_ad += [builder._single_adsorption(ads_use, bond=bond_id, site_index=site_,
+                        # zjwang 20240815 为适配direction='hetero'而改动，可接受多个slab作为list返回
+                        tmp = builder._single_adsorption(ads_use, bond=bond_id, site_index=site_,
                                                                rotation_mode =_rotation_mode,
                                                                rotation_args ={'vec_to_neigh_imgsite':vec_to_neigh_imgsite},
                                                                direction_mode=_direction_mode,
                                                                site_coord = coord_,
-                                                               z_bias=_z_bias)]
+                                                               z_bias=_z_bias)
+                        if type(tmp) == list:
+                            for ii, t in enumerate(tmp):
+                                slab_ad += [t]
+                        else:
+                            slab_ad += [tmp]
                         #if len(bond_atom_ids) > 1:
                         #    slab_ad += [builder._single_adsorption(ads_use, bond=bond_id, site_index=j, direction_mode='decision_boundary', direction_args=bond_atom_ids)]
             else:
@@ -196,11 +202,17 @@ class Adsorption(Structure):
                     coord_ = None
                     if 'site_coords' in self.settings.keys():
                         coord_ = coord
-                    slab_ad += [builder._single_adsorption(ads_use, bond=0, site_index=site_,
+                    tmp = builder._single_adsorption(ads_use, bond=0, site_index=site_,
                                                            rotation_mode =_rotation_mode,
                                                            rotation_args ={'vec_to_neigh_imgsite':vec_to_neigh_imgsite},
+                                                           direction_mode=_direction_mode,
                                                            site_coord = coord_,
-                                                           z_bias=_z_bias)]
+                                                           z_bias=_z_bias)
+                    if type(tmp) == list:
+                        for ii, t in enumerate(tmp):
+                            slab_ad += [t]
+                    else:
+                        slab_ad += [tmp]
         return slab_ad
 
     def Construct_double_adsorption(self):

--- a/example/direction_hetero-PO3_on_W/README.txt
+++ b/example/direction_hetero-PO3_on_W/README.txt
@@ -1,0 +1,28 @@
+StrucInfo:
+  file: slab_W110.vasp
+Model:
+  ads:
+    - [f: 'smi.cif', 1, settings: {site_coords: [[4.7475, 6.714, 0.0], [6.33, 6.714, 0.0], [6.33, 7.45987, 0.0]], direction: 'hetero'}]
+
+===== yaml文件内容如上 =====
+
+
+
+使用：
+
+1）cmd输入命令htmat ads，生成多个吸附结构vasp文件CONTCAR（应有75个），同时输出日志文件score_log.txt，记录各个吸附构型的“评分”
+2）运行top_score.py脚本，将找出得分靠前的几个构型并分别作为POSCAR生成相应的计算目录
+【！重复运行前需删除上一步生成的所有vasp文件，同时删除或清空score_log.txt，否则top_score.py无法正确工作！】
+
+
+
+注：
+
+当direction设置为hetero模式时，将自行确定名义上的 参与吸附原子，用户通过元素或电荷等手段指定吸附原子将不生效
+
+hetero模式适用的吸附分子/物种：
+1）有较明确的“头部基团”，杂原子在分子中相对靠近
+2）同时分子整体球度较低，近似于链状
+如：ALD小分子抑制剂SMIs、SAMs
+
+本例中，由于site_coords中指定了3个坐标，故score_log.txt的内容分3段，每段依次为15个构型的score及排序

--- a/example/direction_hetero-PO3_on_W/config.yaml
+++ b/example/direction_hetero-PO3_on_W/config.yaml
@@ -1,0 +1,6 @@
+StrucInfo:
+  file: slab_W110.vasp
+Model:
+  ads:
+    - [f: 'smi.cif', 1, settings: {site_coords: [[4.7475, 6.714, 0.0], [6.33, 6.714, 0.0], [6.33, 7.45987, 0.0]], direction: 'hetero'}]
+    # 3个坐标依次为top、bridge、hollow位

--- a/example/direction_hetero-PO3_on_W/smi.cif
+++ b/example/direction_hetero-PO3_on_W/smi.cif
@@ -1,0 +1,46 @@
+
+#======================================================================
+# CRYSTAL DATA
+#----------------------------------------------------------------------
+data_VESTA_phase_1
+
+_chemical_name_common                  'C  P  O  H                            '
+_cell_length_a                         20.000000
+_cell_length_b                         20.000000
+_cell_length_c                         20.000000
+_cell_angle_alpha                      90.000000
+_cell_angle_beta                       90.000000
+_cell_angle_gamma                      90.000000
+_cell_volume                           8000.000000
+_space_group_name_H-M_alt              'P 1'
+_space_group_IT_number                 1
+
+loop_
+_space_group_symop_operation_xyz
+   'x, y, z'
+
+loop_
+   _atom_site_label
+   _atom_site_occupancy
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_adp_type
+   _atom_site_B_iso_or_equiv
+   _atom_site_type_symbol
+   C1         1.0     0.559738     0.567097     0.576367    Biso  1.000000 C
+   C2         1.0     0.538675     0.511538     0.528444    Biso  1.000000 C
+   C3         1.0     0.470158     0.524697     0.496636    Biso  1.000000 C
+   P1         1.0     0.439382     0.459509     0.442292    Biso  1.000000 P
+   O1         1.0     0.375792     0.471925     0.407310    Biso  1.000000 O
+   O2         1.0     0.503454     0.446742     0.394082    Biso  1.000000 O
+   O3         1.0     0.434494     0.393122     0.488181    Biso  1.000000 O
+   H1         1.0     0.609292     0.557062     0.597885    Biso  1.000000 H
+   H2         1.0     0.562336     0.615667     0.550620    Biso  1.000000 H
+   H3         1.0     0.523945     0.572164     0.617877    Biso  1.000000 H
+   H4         1.0     0.576254     0.505968     0.488613    Biso  1.000000 H
+   H5         1.0     0.537437     0.463604     0.555894    Biso  1.000000 H
+   H6         1.0     0.471167     0.570961     0.466734    Biso  1.000000 H
+   H7         1.0     0.431303     0.531331     0.535235    Biso  1.000000 H
+   H8         1.0     0.488986     0.431875     0.349897    Biso  1.000000 H
+   H9         1.0     0.477588     0.376746     0.503935    Biso  1.000000 H

--- a/example/direction_hetero-PO3_on_W/top_score.py
+++ b/example/direction_hetero-PO3_on_W/top_score.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+num_top = 3 # 取前几个构型
+
+
+
+fcontent = ''
+with open('score_log.txt', 'r') as f:
+    fcontent = f.read()
+fcontent = fcontent.split('\n')
+
+
+
+scores_l = []
+for i,line in enumerate(fcontent):
+    if ' | ' in line:
+        score = float( line.split('=')[1].split()[0] )
+        scores_l.append(score)
+print('Configurations with top scores:')
+for i in range(num_top):
+    print( np.argsort(scores_l)[::-1][i],  scores_l[np.argsort(scores_l)[::-1][i]])
+
+
+
+if 1: # 如需生成计算文件夹
+    import os, shutil
+    for i in range(num_top):
+        sidx = str( np.argsort(scores_l)[::-1][i] )
+        folder_name = sidx + '_'
+        dir_path = os.path.join(os.getcwd(), folder_name)
+        if not os.path.isdir(dir_path):
+            vasp_files = [f for f in os.listdir('.') if f.endswith(sidx+'.vasp')]
+            os.mkdir(dir_path)
+            shutil.copy(vasp_files[0], os.path.join(dir_path, 'POSCAR'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ scipy >= 0.1
 spglib >= 0.1
 ruamel.yaml > 0.15
 rdkit >= 2022.3.3
-typer[all] >= 0.6
+typer >= 0.6
 scikit-learn >= 1.0.1


### PR DESCRIPTION
相关例子及使用说明见：example/direction_hetero-PO3_on_W
吸附构型评价功能目前仅在direction='hetero'模式下生效，以供top_score.py脚本（例子目录下）挑选最合理的几个构型生成计算目录
不改变之前已有功能的特性